### PR TITLE
Adding Products columng to Advisories page

### DIFF
--- a/apollo/server/templates/advisories.jinja
+++ b/apollo/server/templates/advisories.jinja
@@ -22,6 +22,7 @@
             <bx-table-header-row>
                 <bx-table-header-cell>Name</bx-table-header-cell>
                 <bx-table-header-cell>Synopsis</bx-table-header-cell>
+                <bx-table-header-cell>Products</bx-table-header-cell>
                 <bx-table-header-cell>Created at</bx-table-header-cell>
                 <bx-table-header-cell>Issued at</bx-table-header-cell>
                 <bx-table-header-cell>Kind</bx-table-header-cell>
@@ -33,6 +34,7 @@
             <bx-table-row>
                 <bx-table-cell><a href="/{{ advisory.name }}">{{ advisory.name }}</a></bx-table-cell>
                 <bx-table-cell>{{ advisory.synopsis }}</bx-table-cell>
+                <bx-table-cell>{{ advisory.affected_products if advisory.affected_products else 'N/A' }}</bx-table-cell>
                 <bx-table-cell>{{ advisory.created_at.date() }}</bx-table-cell>
                 <bx-table-cell>{{ advisory.published_at.date() }}</bx-table-cell>
                 <bx-table-cell>{{ advisory.kind }}</bx-table-cell>


### PR DESCRIPTION
  ## Summary
  - Add "Products" column to the advisories listing page
  - Display affected Rocky Linux versions for each advisory
  - Enhance SQL queries to aggregate and display product information
  - Improve user visibility into which products are affected by each advisory

  ## Changes
  - Modified advisory route to include affected products in SQL query
  - Added Products column header in advisories template
  - Display affected products with "N/A" fallback for advisories without product data
  - Updated both search and non-search query paths to include product information