### PR TITLE
Fix InvalidURL exceptions by filtering empty debug/source URLs

### DIFF
--- a/apollo/rpmworker/rh_matcher_activities.py
+++ b/apollo/rpmworker/rh_matcher_activities.py
@@ -628,7 +628,7 @@ async def process_repomd(
     logger = Logger()
     all_pkgs = []
     urls_to_fetch = [
-        rpm_repomd.url, rpm_repomd.debug_url, rpm_repomd.source_url
+        url for url in [rpm_repomd.url, rpm_repomd.debug_url, rpm_repomd.source_url] if url and url.strip()
     ]
     module_packages = {}
     for url in urls_to_fetch:


### PR DESCRIPTION
  ## Summary
  - Critical bug fix to prevent InvalidURL exceptions in RPM worker
  - Filters out empty or whitespace-only debug_url and source_url values
  - Maintains backward compatibility while fixing runtime crashes

  ## Problem
  The RPM worker was attempting to process empty debug_url and source_url values, causing InvalidURL exceptions that would crash the worker process when processing
  repository metadata.

  ## Solution
  Added filtering to only process URLs that are non-empty and contain actual content, preventing attempts to fetch from invalid/empty URLs.