### PR TITLE
Fix null minor version bug

### DIFF
--- a/scripts/generate_rocky_config.py
+++ b/scripts/generate_rocky_config.py
@@ -730,12 +730,21 @@ def generate_rocky_config(
             continue
 
         # Skip if version filter specified and doesn't match
-        if (
-            version
-            and metadata["version"] != version
-            and metadata["version"] != UNKNOWN_VALUE
-        ):
-            continue
+        # Support matching major version only (e.g., "9" matches "9.6")
+        if version and metadata["version"] != UNKNOWN_VALUE:
+            version_matches = False
+
+            # If filter version has no minor (e.g., "9"), match by major version only
+            if "." not in version:
+                # Extract major version from metadata version
+                metadata_major = metadata["version"].split(".")[0] if "." in metadata["version"] else metadata["version"]
+                version_matches = (metadata_major == version)
+            else:
+                # Exact match required for full versions (e.g., "9.6")
+                version_matches = (metadata["version"] == version)
+
+            if not version_matches:
+                continue
 
         # Skip debug repos if not wanted
         if not include_debug and metadata["repo_type"] == "debug":


### PR DESCRIPTION
  This branch fixes a bug in the generate_rocky_config.py script related to version filtering when generating Rocky Linux repository configurations.

  The Specific Change:
  The script now supports flexible version matching when filtering repositories:
  - Major-only filtering (e.g., --version 9): Matches any minor version within that major version (9.0, 9.1, 9.2, 9.6, etc.)
  - Full version filtering (e.g., --version 9.6): Requires exact match to the specified major.minor version

  Why This Change Is Needed

  The Problem:
  Red Hat's advisory format varies across RHEL versions:
  - RHEL 8 & 9: Red Hat advisories typically don't include minor versions (they just reference "RHEL 8" or "RHEL 9")
  - RHEL 10+: Red Hat now includes minor versions in advisories (e.g., "RHEL 10.2", "RHEL 10.3")

  This creates a version matching issue in Apollo's mirror configuration system:

  1. The supported_products_rh_mirrors table defines which Red Hat advisories to match against Rocky Linux versions
  2. The table has match_major_version and match_minor_version columns to control matching
  3. For RHEL 8/9, match_minor_version should be NULL (matches any minor version)
  4. For RHEL 10+, match_minor_version should be set (matches specific minor versions)

  Without this fix:
  - If you run generate_rocky_config.py --version 9 against a Rocky 9.6 mirror, it would fail to include repos because it expected an exact version
  match
  - This makes it impossible to generate configs that match the "major version only" pattern needed for RHEL 8/9 mirroring

  With this fix:
  - Using --version 9 correctly generates configs with NULL match_minor_version (matches RHEL 9.x advisories)
  - Using --version 9.6 generates configs with match_minor_version = 6 (for RHEL 10+ style matching)

  How It Fits Into Apollo

  Apollo's Advisory Mirroring Workflow:

  1. Ingestion: The rhworker polls Red Hat for new advisories (RHSA, RHBA, RHEA)
  2. Matching: Apollo uses supported_products_rh_mirrors to determine which Rocky Linux products each Red Hat advisory applies to
    - Matches by variant (RHEL), major version, minor version (if specified), and architecture
  3. Package Mapping: The rpmworker finds equivalent packages in Rocky repos and generates Rocky advisories
  4. Config Generation: The generate_rocky_config.py script creates/updates the supported_products_rpm_repomds and supported_products_rh_mirrors
  tables