### PR TITLE
Fix package_name NULL constraint violation in AdvisoryPackage ORM

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,7 @@ jobs:
         bazel test //apollo/tests:test_admin_routes_supported_products --test_output=all
         bazel test //apollo/tests:test_api_osv --test_output=all
         bazel test //apollo/tests:test_database_service --test_output=all
+        bazel test //apollo/tests:test_rh_matcher_activities --test_output=all
 
     - name: Integration Tests
       run: ./build/scripts/test.bash

--- a/apollo/db/__init__.py
+++ b/apollo/db/__init__.py
@@ -321,8 +321,8 @@ class AdvisoryPackage(Model):
 
     def __init__(self, **kwargs):
         if 'package_name' in kwargs:
-            kwargs['package_name'] = self._clean_package_name(
-                kwargs['package_name']
+            kwargs['_package_name'] = self._clean_package_name(
+                kwargs.pop('package_name')
             )
         super().__init__(**kwargs)
 

--- a/apollo/rpmworker/rh_matcher_activities.py
+++ b/apollo/rpmworker/rh_matcher_activities.py
@@ -495,14 +495,24 @@ async def clone_advisory(
                     "{http://linux.duke.edu/metadata/common}format"
                 ).find("{http://linux.duke.edu/metadata/rpm}sourcerpm")
 
-                # This means we're checking a source RPM
+                package_name = None
                 if advisory_nvra.endswith(".src.rpm"
                                          ) or advisory_nvra.endswith(".src"):
                     source_nvra = repomd.NVRA_RE.search(advisory_nvra)
-                    package_name = source_nvra.group(1)
-                else:
+                    if source_nvra:
+                        package_name = source_nvra.group(1)
+                elif source_rpm is not None and source_rpm.text:
                     source_nvra = repomd.NVRA_RE.search(source_rpm.text)
-                    package_name = source_nvra.group(1)
+                    if source_nvra:
+                        package_name = source_nvra.group(1)
+
+                if not package_name:
+                    logger.warning(
+                        "Could not extract package_name for %s in advisory %s, skipping package",
+                        nevra,
+                        advisory.name,
+                    )
+                    continue
 
                 checksum_tree = pkg.find(
                     "{http://linux.duke.edu/metadata/common}checksum"

--- a/apollo/tests/BUILD.bazel
+++ b/apollo/tests/BUILD.bazel
@@ -88,3 +88,12 @@ py_test(
         "//common:common_lib",
     ],
 )
+
+py_test(
+    name = "test_rh_matcher_activities",
+    srcs = ["test_rh_matcher_activities.py"],
+    deps = [
+        "//apollo/rpmworker:rpmworker_lib",
+        "//apollo/rpm_helpers:rpm_helpers_lib",
+    ],
+)

--- a/apollo/tests/test_rh_matcher_activities.py
+++ b/apollo/tests/test_rh_matcher_activities.py
@@ -1,0 +1,131 @@
+"""
+Tests for RH matcher activities package_name extraction logic
+"""
+
+import unittest
+import sys
+import os
+from unittest.mock import Mock, MagicMock, patch
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from apollo.rpmworker import repomd
+
+
+class TestPackageNameExtraction(unittest.TestCase):
+    """Test package_name extraction from source RPMs"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.test_advisory_nvra = "libarchive-3.3.3-5.el8.src.rpm"
+        self.test_binary_nvra = "libarchive-0:3.3.3-5.el8.x86_64.rpm"
+        self.test_debuginfo_nvra = "libarchive-debuginfo-0:3.3.3-5.el8.aarch64.rpm"
+
+    def test_nvra_regex_matches_source_rpm(self):
+        """Test NVRA_RE regex matches source RPM correctly"""
+        match = repomd.NVRA_RE.search(self.test_advisory_nvra)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1), "libarchive")
+
+    def test_nvra_regex_matches_binary_rpm(self):
+        """Test NVRA_RE regex matches binary RPM name"""
+        source_rpm_text = "libarchive-3.3.3-5.el8.src.rpm"
+        match = repomd.NVRA_RE.search(source_rpm_text)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1), "libarchive")
+
+    def test_nvra_regex_handles_module_packages(self):
+        """Test NVRA_RE regex extracts package name from module packages"""
+        module_source_rpm = "postgresql-12.5-1.module+el8.3.0+6656+95b1e5d5.src.rpm"
+        match = repomd.NVRA_RE.search(module_source_rpm)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1), "postgresql")
+
+    def test_nvra_regex_no_match_returns_none(self):
+        """Test NVRA_RE regex returns None for invalid format"""
+        invalid_nvra = "not-a-valid-package-name"
+        match = repomd.NVRA_RE.search(invalid_nvra)
+        self.assertIsNone(match)
+
+    def test_source_rpm_element_handling(self):
+        """Test handling of missing source_rpm XML element"""
+        xml_with_sourcerpm = """
+        <package xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+            <format>
+                <rpm:sourcerpm>libarchive-3.3.3-5.el8.src.rpm</rpm:sourcerpm>
+            </format>
+        </package>
+        """
+        xml_without_sourcerpm = """
+        <package xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+            <format>
+            </format>
+        </package>
+        """
+
+        root_with = ET.fromstring(xml_with_sourcerpm)
+        source_rpm_with = root_with.find("format").find("{http://linux.duke.edu/metadata/rpm}sourcerpm")
+        self.assertIsNotNone(source_rpm_with)
+
+        root_without = ET.fromstring(xml_without_sourcerpm)
+        source_rpm_without = root_without.find("format").find("{http://linux.duke.edu/metadata/rpm}sourcerpm")
+        self.assertIsNone(source_rpm_without)
+
+    def test_package_name_extraction_workflow(self):
+        """Test complete workflow of package_name extraction with various scenarios"""
+        test_cases = [
+            {
+                "name": "Valid source RPM",
+                "advisory_nvra": "libarchive-3.3.3-5.el8.src.rpm",
+                "is_source": True,
+                "source_rpm_text": None,
+                "expected": "libarchive"
+            },
+            {
+                "name": "Valid binary RPM with source",
+                "advisory_nvra": "libarchive-0:3.3.3-5.el8.x86_64",
+                "is_source": False,
+                "source_rpm_text": "libarchive-3.3.3-5.el8.src.rpm",
+                "expected": "libarchive"
+            },
+            {
+                "name": "Binary RPM with missing source",
+                "advisory_nvra": "libarchive-debuginfo-0:3.3.3-5.el8.aarch64",
+                "is_source": False,
+                "source_rpm_text": None,
+                "expected": None
+            },
+            {
+                "name": "Invalid source RPM format",
+                "advisory_nvra": "invalid-format",
+                "is_source": True,
+                "source_rpm_text": None,
+                "expected": None
+            },
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case=test_case["name"]):
+                advisory_nvra = test_case["advisory_nvra"]
+                is_source = test_case["is_source"]
+                source_rpm_text = test_case["source_rpm_text"]
+                expected = test_case["expected"]
+
+                package_name = None
+
+                if advisory_nvra.endswith(".src.rpm") or advisory_nvra.endswith(".src"):
+                    source_nvra = repomd.NVRA_RE.search(advisory_nvra)
+                    if source_nvra:
+                        package_name = source_nvra.group(1)
+                elif source_rpm_text:
+                    source_nvra = repomd.NVRA_RE.search(source_rpm_text)
+                    if source_nvra:
+                        package_name = source_nvra.group(1)
+
+                self.assertEqual(package_name, expected,
+                               f"Failed for {test_case['name']}: expected {expected}, got {package_name}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The AdvisoryPackage.__init__() method was dropping all package_name values due to incorrect field attribute handling when using Tortoise ORM source_field mapping. The field _package_name maps to DB column package_name, but __init__ was setting kwargs['package_name'] instead of kwargs['_package_name'], causing values to be silently ignored.

Also adds null checks in package extraction logic to skip packages when package_name cannot be determined from source RPM metadata.